### PR TITLE
(fix) rename buffer.length to data.length

### DIFF
--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ var PythonStruct = {
                 if (unpack) {
 					
 					if (checkBounds) {
-                        if (position + size >= buffer.length) {
+                        if (position + size >= data.length) {
                             throw new Error('Reached end of buffer, can\'t unpack anymore data.');
                         }
                     }


### PR DESCRIPTION
Using checkbounds in unpack would break because there's no buffer.length (a typo). Changing it to data.length fixes the problem 👍 