### PR TITLE
(feat) rely on buffer package to polyfill buffer on browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 const Long = require('long');
+// If Node.js doesn't supply buffer, then load a replacement.
+// This will occur on browsers.
+if (!Buffer) Buffer = require('buffer/').Buffer;
 
 /**
  *  Copied over from python's notes:

--- a/index.js
+++ b/index.js
@@ -1,7 +1,14 @@
 const Long = require('long');
 // If Node.js doesn't supply buffer, then load a replacement.
 // This will occur on browsers.
-if (!Buffer) Buffer = require('buffer/').Buffer;
+if (!Buffer) {
+    try {
+        Buffer = require('buffer/').Buffer;
+    } catch (e) {
+        throw new Error("You're using a platform that doesn't have buffer support!\n" +
+                        "Install feross/buffer module through your package manager.");
+    }
+}
 
 /**
  *  Copied over from python's notes:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/danielgindi/node-python-struct",
   "dependencies": {
+    "buffer": "^5.1.0",
     "long": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/danielgindi/node-python-struct",
   "dependencies": {
-    "buffer": "^5.1.0",
     "long": "^3.2.0"
   }
 }


### PR DESCRIPTION
Not sure if you want this, given that your package was written explicitly for Node.js. This adds a polyfill to fix the missing Buffer class on browsers